### PR TITLE
Add S3 Versioning - Closes #12

### DIFF
--- a/MultiAccountApplication/template.yaml
+++ b/MultiAccountApplication/template.yaml
@@ -49,6 +49,8 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "${AWS::AccountId}-${AWS::Region}-${CarbonEmissionsDataBucketName}"
+      VersioningConfiguration:
+        Status: Enabled
 
   # -------------------------------------------------------------------------------------------------------------------
   # Create an S3 bucket to be used as Athena output location, with a retention time of files of 1 day.
@@ -63,6 +65,8 @@ Resources:
           - Id: DeleteAfterOneDay
             Status: Enabled
             ExpirationInDays: 1
+      VersioningConfiguration:
+        Status: Enabled
 
   # -------------------------------------------------------------------------------------------------------------------
   # Create an AWS Step Function State Machine and a EventBridge rule to trigger the Step Functions workflow.


### PR DESCRIPTION
_07/08/2024 corrected from_ [S3.10] S3 general purpose buckets with versioning enabled should have Lifecycle configurations
_to_ **[S3.14] [S3 general purpose buckets should have versioning enabled]**(https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-14)

*Issue #12 :*

*Description of changes:*

Adds versioning to the S3 Buckets to resolve the AWS Securityhub finding: _07/08/2024 corrected from_ [S3.10] S3 general purpose buckets with versioning enabled should have Lifecycle configurations _to_ **[S3.14] [S3 general purpose buckets should have versioning enabled]**

_07/08/2024 readded_: 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.