### PR TITLE
Added functionality to filter out accounts in SUSPENDED or PENDING_CLOSURE state

### DIFF
--- a/MultiAccountApplication/lambda_functions/get_account_ids/app.py
+++ b/MultiAccountApplication/lambda_functions/get_account_ids/app.py
@@ -64,8 +64,13 @@ def lambda_handler(event, _):
         # Retrieve the ID of the management account
         management_account_id = org_client.describe_organization()['Organization']['MasterAccountId']
 
-        # Retrieve all account IDs in the organization
-        accounts = [account["Id"] for page in paginator.paginate() for account in page["Accounts"]]
+        # Retrieve all active account IDs in the organization (filtering out accounts in status SUSPENDED or PENDING_CLOSURE)
+        accounts = [
+            account["Id"]
+            for page in paginator.paginate()
+            for account in page["Accounts"]
+            if account["Status"] == "ACTIVE"  # Filter for active accounts
+        ]
 
         # move the management account to the first index
         accounts.remove(management_account_id)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`get-account-ids` Lambda function now filters out accounts that are in status `SUSPENDED` or `PENDING_CLOSURE` and will only pass on account ID's that are in status `ACTIVE` . It is not possible to assume a role in an account in state suspended or pending closure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
