### PR TITLE
Feat/add aws lambda basic execution role rights to function and upgrade request timeout

### DIFF
--- a/MultiAccountApplication/lambda_functions/extract_carbon_emissions/ccft_access.py
+++ b/MultiAccountApplication/lambda_functions/extract_carbon_emissions/ccft_access.py
@@ -55,7 +55,7 @@ def extract_emissions_data(startDate, endDate, credentials):
 
     try:
         response = requests.request(
-            method, url, headers=dict(request.headers), data={}, timeout=5
+            method, url, headers=dict(request.headers), data={}, timeout=20
         )
         response.raise_for_status()
     except Exception as e:

--- a/MultiAccountApplication/template.yaml
+++ b/MultiAccountApplication/template.yaml
@@ -179,6 +179,7 @@ Resources:
       CodeUri: lambda_functions/get_account_ids/
       Handler: app.lambda_handler
       Policies:
+        - AWSLambdaBasicExecutionRole
         - Statement:
           - Sid: ListAccounts
             Effect: Allow
@@ -218,6 +219,7 @@ Resources:
       CodeUri: lambda_functions/check_first_invocation/
       Handler: app.lambda_handler
       Policies:
+        - AWSLambdaBasicExecutionRole
         - S3ReadPolicy:
             BucketName: !Ref CarbonEmissionsDataBucket
         - Statement:
@@ -297,6 +299,8 @@ Resources:
       FunctionName: "extract-carbon-emissions-data"
       CodeUri: lambda_functions/extract_carbon_emissions/
       Handler: app.lambda_handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
       Role: !GetAtt ExtractCarbonEmissionsLambdaRole.Arn
       Runtime: python3.11
       Architectures:
@@ -343,6 +347,7 @@ Resources:
       CodeUri: lambda_functions/create_alter_athena_view/
       Handler: app.lambda_handler
       Policies:
+        - AWSLambdaBasicExecutionRole
         - Statement:
           - Sid: Athena
             Effect: Allow


### PR DESCRIPTION
2 features/request:

* Allow by default lambdas to put logs into cloudwatch logs by adding the managed policy AWSLambdaBasicExecutionRole to their roles.

* Increase the time out from 5s to 20s for the https call to the ccft as 5 sec can be not enough for 40 months of data. 
